### PR TITLE
Check if `apiKey` exists

### DIFF
--- a/addon/initializers/router.js
+++ b/addon/initializers/router.js
@@ -3,7 +3,9 @@ import Ember from 'ember';
 export function initialize() {
   Ember.Router.reopen({
     pendoPageLoad: function() {
-      window.pendo.pageLoad();
+      if(window.pendo) {
+        window.pendo.pageLoad();
+      }
     }.on('didTransition')
   });
 }

--- a/index.js
+++ b/index.js
@@ -7,10 +7,12 @@ module.exports = {
     return false;
   },
   contentFor: function(type, config) {
-    if (type === 'head' && config.environment !== 'test') {
+    var apiKey = config['ember-cli-pendo'] ? config['ember-cli-pendo'].apiKey : null;
+
+    if (type === 'head' && config.environment !== 'test' && apiKey) {
       return "<script>\n" +
         "window.pendo_options = {\n" +
-        "  apiKey: '" + config['ember-cli-pendo'].apiKey + "',\n" +
+        "  apiKey: '" + apiKey + "',\n" +
         "  // This is required to be able to load data client side\n" +
         "  usePendoAgentAPI: true\n" +
         "};\n" +


### PR DESCRIPTION
If ember-cli-pendo options are not provided, the plugin will fail with an error. This PR fixes the situation to only run pendo code when options with the `apiKey` are provided.